### PR TITLE
update timestamp field name

### DIFF
--- a/macros/stitch/base/stitch_bing_keyword_performance.sql
+++ b/macros/stitch/base/stitch_bing_keyword_performance.sql
@@ -19,7 +19,7 @@ renamed as (
     
         "__SDC_PRIMARY_KEY" as keyword_performance_report_id,
 
-        convert_timezone('UTC', gregoriandate)::timestamp_ntz::date 
+        convert_timezone('UTC', timeperiod)::timestamp_ntz::date 
             as campaign_date,
             
         accountid as account_id,
@@ -42,7 +42,7 @@ renamed as (
         spend,
         
         rank() over (
-            partition by gregoriandate::date 
+            partition by timeperiod::date 
             order by _sdc_report_datetime desc
             ) as rank
 


### PR DESCRIPTION
* in the most recent update to [Stitch's Bing connector](https://www.stitchdata.com/docs/integrations/saas/bing-ads), the `gregoriandate` > `timeperiod`
* this simply updates for the new field name of the timestamp (tests and runs have passed on Snowflake, I have not tested on Redshift but this shouldn't be a breaking change)